### PR TITLE
CCS-25 Add Wikipedia API integration with editor and tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1760,7 +1760,22 @@ files = [
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)"]
 
+[[package]]
+name = "wikipedia"
+version = "1.4.0"
+description = "Wikipedia API for Python"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "wikipedia-1.4.0.tar.gz", hash = "sha256:db0fad1829fdd441b1852306e9856398204dc0786d2996dd2e0c8bb8e26133b2"},
+]
+
+[package.dependencies]
+beautifulsoup4 = "*"
+requests = ">=2.0.0,<3.0.0"
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.9.7 || >3.9.7,<4.0"
-content-hash = "34f99faf53dd491aea02bf395f2085c7a51205f0cf17539bca1d69d25893f85c"
+content-hash = "c3b3e23dac3a2239fd3e9bc762301c68bee7b8786b24340d4bef2c2e6122bd39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "PyMuPDF (>=1.23.0,<2.0.0)",
     "beautifulsoup4 (>=4.12.0,<5.0.0)",
     "reportlab (>=4.1.0,<5.0.0)",
-    "Pillow (>=10.0.0,<11.0.0)"
+    "Pillow (>=10.0.0,<11.0.0)",
+    "wikipedia (>=1.4.0,<2.0.0)"
 ]
 
 [tool.poetry]

--- a/src/NoKeeA/UI/streamlit_content.py
+++ b/src/NoKeeA/UI/streamlit_content.py
@@ -2,16 +2,36 @@ import streamlit as st
 from streamlit_quill import st_quill
 from NoKeeA.utils.session_state import initialize_session_state
 from NoKeeA.utils.wikipedia_api import get_wikipedia_summary
+import time
+
+
+def update_quill_editor():
+    """
+    Updates the editor key in Streamlit's session state to trigger a re-render.
+
+    The key is dynamically generated based on the current time and the loaded note name.
+    This ensures the editor is refreshed, e.g., after inserting new content.
+    """
+    st.session_state["editor_key"] = f"editor_{time.time()}_{st.session_state.get('loaded_note', 'new')}"
 
 
 def content():
-    """Render the main content area with the editor."""
-    # Ensure session state is initialized
+    """
+    Renders the main content area: Quill editor and Wikipedia search.
+
+    Features:
+    - Initializes session state.
+    - Displays a rich text editor with a configured toolbar.
+    - Allows searching for Wikipedia articles.
+    - Shows article summaries.
+    - Appends article summaries to the note on button click.
+    - Uses dynamic keys to force editor refresh when needed.
+    """
     initialize_session_state()
 
     st.subheader("📝 Notiz bearbeiten")
 
-    # Editor mit Callback für Änderungen
+    # Editor with dynamic key
     content = st_quill(
         value=st.session_state.get("editor_content", ""),
         html=True,
@@ -25,15 +45,13 @@ def content():
             ["link", "image", "video", "formula"],
             ["blockquote", "code-block"]
         ],
-        key=f"editor_{st.session_state.get('loaded_note', 'new')}"
+        key=st.session_state["editor_key"]
     )
 
-    # Aktualisiere den Session State IMMER mit dem aktuellen Inhalt
-    st.session_state["editor_content"] = (
-        content if content is not None
-        else st.session_state.get("editor_content", "")
-    )
+    if content is not None:
+        st.session_state["editor_content"] = content
 
+    # Wikipedia search
     with st.expander("📚 Wikipedia-Suche"):
         wiki_term = st.text_input("🔍 Begriff eingeben", key="wiki_editor_term")
 
@@ -42,6 +60,7 @@ def content():
                 try:
                     result = get_wikipedia_summary(wiki_term)
                     if "summary" in result:
+                        st.session_state["wiki_result"] = result  # store result temporarily
                         st.success(result["summary"])
                         st.markdown(f"[🔗 Zum Artikel]({result['url']})", unsafe_allow_html=True)
                     else:
@@ -51,3 +70,17 @@ def content():
             else:
                 st.info("Bitte gib einen gültigen Begriff ein.")
 
+        # Show insert button if a result is available
+        if "wiki_result" in st.session_state and st.session_state["wiki_result"]:
+            if st.button("📥 In Notiz einfügen"):
+                summary = st.session_state["wiki_result"]["summary"]
+                current_content = st.session_state.get("editor_content", "")
+                new_content = current_content + f"<p>{summary}</p>"
+                st.session_state["editor_content"] = new_content
+
+                # Clear only the stored Wikipedia result (not the search term)
+                st.session_state.pop("wiki_result", None)
+
+                # Trigger editor refresh with new key
+                update_quill_editor()
+                st.rerun()

--- a/src/NoKeeA/UI/streamlit_content.py
+++ b/src/NoKeeA/UI/streamlit_content.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from streamlit_quill import st_quill
 from NoKeeA.utils.session_state import initialize_session_state
+from NoKeeA.utils.wikipedia_api import get_wikipedia_summary
 
 
 def content():
@@ -32,3 +33,16 @@ def content():
         content if content is not None
         else st.session_state.get("editor_content", "")
     )
+
+    with st.expander("📚 Wikipedia-Suche"):
+        wiki_term = st.text_input("🔍 Begriff eingeben", key="wiki_editor_term")
+        if st.button("🔎 Wikipedia nachschlagen"):
+            if wiki_term:
+                result = get_wikipedia_summary(wiki_term)
+                if "summary" in result:
+                    st.success(result["summary"])
+                    st.markdown(f"[🔗 Zum Artikel]({result['url']})", unsafe_allow_html=True)
+                else:
+                    st.error(result["error"])
+            else:
+                st.info("Bitte gib einen Begriff ein.")

--- a/src/NoKeeA/UI/streamlit_content.py
+++ b/src/NoKeeA/UI/streamlit_content.py
@@ -36,13 +36,18 @@ def content():
 
     with st.expander("📚 Wikipedia-Suche"):
         wiki_term = st.text_input("🔍 Begriff eingeben", key="wiki_editor_term")
+
         if st.button("🔎 Wikipedia nachschlagen"):
-            if wiki_term:
-                result = get_wikipedia_summary(wiki_term)
-                if "summary" in result:
-                    st.success(result["summary"])
-                    st.markdown(f"[🔗 Zum Artikel]({result['url']})", unsafe_allow_html=True)
-                else:
-                    st.error(result["error"])
+            if wiki_term and isinstance(wiki_term, str) and wiki_term.strip():
+                try:
+                    result = get_wikipedia_summary(wiki_term)
+                    if "summary" in result:
+                        st.success(result["summary"])
+                        st.markdown(f"[🔗 Zum Artikel]({result['url']})", unsafe_allow_html=True)
+                    else:
+                        st.error(result["error"])
+                except Exception as e:
+                    st.error(f"❌ Fehler bei Wikipedia-Abfrage: {e}")
             else:
-                st.info("Bitte gib einen Begriff ein.")
+                st.info("Bitte gib einen gültigen Begriff ein.")
+

--- a/src/NoKeeA/UI/streamlit_sidebar.py
+++ b/src/NoKeeA/UI/streamlit_sidebar.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from NoKeeA.utils.wikipedia_api import get_wikipedia_summary
 from NoKeeA.utils.file_operations import save_note, delete_note, \
     load_note, list_notes
 from NoKeeA.utils.session_state import initialize_session_state
@@ -183,23 +182,5 @@ def render_sidebar():
             )
         else:
             st.sidebar.error("❌ Fehler beim Vorbereiten des Exports.")
-        
-    # Wikipedia Lookup Section
-    st.sidebar.markdown("---")
-    st.sidebar.subheader("📚 Wikipedia-Suche")
-
-    wiki_term = st.sidebar.text_input("🔍 Begriff eingeben")
-
-    if st.sidebar.button("🔎 Nachschlagen"):
-        if wiki_term:
-            result = get_wikipedia_summary(wiki_term)
-            if "summary" in result:
-                st.sidebar.success(result["summary"])
-                st.sidebar.markdown(f"[🔗 Zum Artikel]({result['url']})", unsafe_allow_html=True)
-            else:
-                st.sidebar.error(result["error"])
-        else:
-            st.sidebar.info("Bitte gib einen Begriff ein.")
-
     else:
         st.sidebar.info("ℹ️ Keine Notiz zum Exportieren vorhanden.")

--- a/src/NoKeeA/UI/streamlit_sidebar.py
+++ b/src/NoKeeA/UI/streamlit_sidebar.py
@@ -5,10 +5,20 @@ from NoKeeA.utils.session_state import initialize_session_state
 from NoKeeA.utils.file_import_export import import_file, export_file, \
     get_supported_extensions
 import os
+from .streamlit_content import update_quill_editor
 
 
 def render_sidebar():
-    """Render the sidebar with controls"""
+    """
+    Renders the Streamlit sidebar with note management and import/export functionality.
+
+    This function allows the user to:
+    - Load existing notes
+    - Create, rename, save, or delete notes
+    - Import files as new notes or append to existing ones
+    - Export current note content in various formats
+    """
+
     initialize_session_state()
 
     st.sidebar.title("⚙️ Einstellungen")
@@ -34,6 +44,7 @@ def render_sidebar():
             note_data = load_note(selected_note)
             st.session_state["editor_content"] = note_data["content"]
             st.session_state["loaded_note"] = note_data["name"]
+            update_quill_editor()
             st.session_state["note_name"] = note_data["name"]
             st.session_state["last_loaded_note"] = selected_note
             st.sidebar.success(f"✅ Notiz '{selected_note}' geladen.")
@@ -56,6 +67,7 @@ def render_sidebar():
                     st.session_state.get("editor_content", "")
                 )
                 st.session_state["loaded_note"] = st.session_state["note_name"]
+                update_quill_editor()
                 st.sidebar.success(
                     f"✅ Notiz '{st.session_state['note_name']}' gespeichert.")
             except Exception as e:
@@ -72,6 +84,7 @@ def render_sidebar():
                 # Reset all relevant session state variables
                 st.session_state["editor_content"] = ""
                 st.session_state["loaded_note"] = ""
+                update_quill_editor()
                 st.session_state["note_name"] = ""
                 st.session_state["last_loaded_note"] = None
             else:
@@ -85,6 +98,7 @@ def render_sidebar():
         st.session_state["note_name"] = new_note_name
         st.session_state["editor_content"] = ""
         st.session_state["loaded_note"] = new_note_name
+        update_quill_editor()
         st.session_state["last_loaded_note"] = new_note_name
 
         # Save the empty note immediately
@@ -97,6 +111,7 @@ def render_sidebar():
             st.session_state["note_name"] = ""
             st.session_state["loaded_note"] = ""
             st.session_state["last_loaded_note"] = None
+            update_quill_editor()
 
     # Import/Export section
     st.sidebar.markdown("---")
@@ -132,6 +147,7 @@ def render_sidebar():
                     st.session_state["last_loaded_note"] = None
                     st.sidebar.success(
                         f"✅ Datei '{uploaded_file.name}' importiert.")
+                    update_quill_editor()
                 else:
                     # Append to current content with a separator
                     current_content = st.session_state.get(

--- a/src/NoKeeA/UI/streamlit_sidebar.py
+++ b/src/NoKeeA/UI/streamlit_sidebar.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from NoKeeA.utils.wikipedia_api import get_wikipedia_summary
 from NoKeeA.utils.file_operations import save_note, delete_note, \
     load_note, list_notes
 from NoKeeA.utils.session_state import initialize_session_state
@@ -182,5 +183,23 @@ def render_sidebar():
             )
         else:
             st.sidebar.error("❌ Fehler beim Vorbereiten des Exports.")
+        
+    # Wikipedia Lookup Section
+    st.sidebar.markdown("---")
+    st.sidebar.subheader("📚 Wikipedia-Suche")
+
+    wiki_term = st.sidebar.text_input("🔍 Begriff eingeben")
+
+    if st.sidebar.button("🔎 Nachschlagen"):
+        if wiki_term:
+            result = get_wikipedia_summary(wiki_term)
+            if "summary" in result:
+                st.sidebar.success(result["summary"])
+                st.sidebar.markdown(f"[🔗 Zum Artikel]({result['url']})", unsafe_allow_html=True)
+            else:
+                st.sidebar.error(result["error"])
+        else:
+            st.sidebar.info("Bitte gib einen Begriff ein.")
+
     else:
         st.sidebar.info("ℹ️ Keine Notiz zum Exportieren vorhanden.")

--- a/src/NoKeeA/utils/session_state.py
+++ b/src/NoKeeA/utils/session_state.py
@@ -2,12 +2,23 @@ import streamlit as st
 
 
 def initialize_session_state():
-    """Initialize all required session state variables."""
+    """
+    Initialize all required keys in the Streamlit session state.
+
+    This ensures that the editor and note-related features work reliably 
+    by setting default values for keys if they are not already present.
+    """
     if "editor_content" not in st.session_state:
         st.session_state["editor_content"] = ""
+
     if "loaded_note" not in st.session_state:
         st.session_state["loaded_note"] = ""
+
     if "note_name" not in st.session_state:
         st.session_state["note_name"] = ""
+
     if "last_loaded_note" not in st.session_state:
         st.session_state["last_loaded_note"] = None
+
+    if "editor_key" not in st.session_state:
+        st.session_state["editor_key"] = None

--- a/src/NoKeeA/utils/wikipedia_api.py
+++ b/src/NoKeeA/utils/wikipedia_api.py
@@ -1,9 +1,23 @@
 import wikipedia
 
-# Sprache auf Deutsch setzen
+
+# Set language to German
 wikipedia.set_lang("de")
 
 def get_wikipedia_summary(term: str, sentences: int = 3) -> dict:
+    """
+    Searches Wikipedia for a given term and returns a short summary.
+
+    Args:
+        term (str): The search term to look up on Wikipedia.
+        sentences (int, optional): Number of sentences to include in the summary. Default is 3.
+
+    Returns:
+        dict: A dictionary containing either:
+            - "summary" (str): The summary text of the article.
+            - "url" (str): The full URL to the Wikipedia page.
+            - "error" (str): An error message if the article could not be retrieved or the term is ambiguous.
+    """
     try:
         summary = wikipedia.summary(term, sentences=sentences)
         page = wikipedia.page(term)

--- a/src/NoKeeA/utils/wikipedia_api.py
+++ b/src/NoKeeA/utils/wikipedia_api.py
@@ -1,0 +1,17 @@
+import wikipedia
+
+# Sprache auf Deutsch setzen
+wikipedia.set_lang("de")
+
+def get_wikipedia_summary(term: str, sentences: int = 3) -> dict:
+    try:
+        summary = wikipedia.summary(term, sentences=sentences)
+        page = wikipedia.page(term)
+        return {
+            "summary": summary,
+            "url": page.url
+        }
+    except wikipedia.exceptions.DisambiguationError as e:
+        return {"error": f"Mehrdeutiger Begriff. Beispiele: {', '.join(e.options[:3])}"}
+    except wikipedia.exceptions.PageError:
+        return {"error": "Kein Wikipedia-Eintrag gefunden."}

--- a/tests/UI/test_streamlit_content.py
+++ b/tests/UI/test_streamlit_content.py
@@ -1,15 +1,21 @@
+import time
 import pytest
 from unittest.mock import patch, MagicMock
+from NoKeeA.UI import streamlit_content
 
 
 @pytest.fixture
 def mock_streamlit():
+    """
+    Mocks the Streamlit module and sets up default session state values.
+    """
     with patch('NoKeeA.UI.streamlit_content.st') as mock_st:
         mock_st.session_state = {
             "editor_content": "",
             "loaded_note": "",
             "note_name": "",
-            "last_loaded_note": None
+            "last_loaded_note": None,
+            "editor_key": time.time()
         }
         mock_st.subheader = MagicMock()
         yield mock_st
@@ -17,12 +23,18 @@ def mock_streamlit():
 
 @pytest.fixture
 def mock_quill():
+    """
+    Mocks the st_quill editor.
+    """
     with patch('NoKeeA.UI.streamlit_content.st_quill') as mock_st_quill:
         yield mock_st_quill
 
 
 @pytest.fixture
 def mock_session_state():
+    """
+    Mocks the session state initialization function.
+    """
     with patch(
         'NoKeeA.UI.streamlit_content.initialize_session_state'
     ) as mock_init:
@@ -30,51 +42,44 @@ def mock_session_state():
 
 
 def test_editor_initialization(mock_streamlit, mock_quill, mock_session_state):
-    """Test if editor initializes with empty content"""
+    """
+    Tests if the editor initializes with empty content.
+    """
     from NoKeeA.UI.streamlit_content import content
     content()
 
-    # Verify session state initialization was called
     mock_session_state.assert_called_once()
-
     mock_quill.assert_called_once()
-    # Verify default empty content
     assert mock_quill.call_args[1]['value'] == ""
 
 
-def test_editor_with_existing_content(
-        mock_streamlit, mock_quill, mock_session_state
-):
-    """Test if editor loads content from session state"""
+def test_editor_with_existing_content(mock_streamlit, mock_quill, mock_session_state):
+    """
+    Tests if existing content from session state is loaded into the editor.
+    """
     from NoKeeA.UI.streamlit_content import content
-    # Set up session state with content
     mock_streamlit.session_state["editor_content"] = "Existing content"
     content()
 
-    # Verify session state initialization was called
     mock_session_state.assert_called_once()
-
     mock_quill.assert_called_once()
-    # Verify content from session state
     assert mock_quill.call_args[1]['value'] == "Existing content"
 
 
-def test_editor_toolbar_configuration(
-        mock_streamlit, mock_quill, mock_session_state
-):
-    """Test if editor toolbar is configured correctly"""
+def test_editor_toolbar_configuration(mock_streamlit, mock_quill, mock_session_state):
+    """
+    Tests the toolbar configuration for the Quill editor.
+    """
     from NoKeeA.UI.streamlit_content import content
     content()
 
-    # Verify session state initialization was called
     mock_session_state.assert_called_once()
-
     toolbar = mock_quill.call_args[1]['toolbar']
 
-    # Test text formatting features
+    # Basic formatting tools
     assert ["bold", "italic", "underline", "strike"] in toolbar
 
-    # Test font and size options
+    # Font and size options
     font_options = None
     size_options = None
     for item in toolbar:
@@ -83,41 +88,93 @@ def test_editor_toolbar_configuration(
         if isinstance(item[0], dict) and "size" in item[0]:
             size_options = item[0]["size"]
 
-    assert font_options is not None, "Font options not found in toolbar"
-    assert "Arial" in font_options, "Arial font not available"
-    assert "monospace" in font_options, "Monospace font not available"
+    assert font_options is not None
+    assert "Arial" in font_options
+    assert "monospace" in font_options
 
-    assert size_options is not None, "Size options not found in toolbar"
-    assert "small" in size_options, "Small size not available"
-    assert "large" in size_options, "Large size not available"
+    assert size_options is not None
+    assert "small" in size_options
+    assert "large" in size_options
 
-    # Test alignment options
+    # Alignment options
     align_options = None
     for item in toolbar:
         if isinstance(item[0], dict) and "align" in item[0]:
             align_options = item
             break
-    assert align_options is not None, "Alignment options not found"
+    assert align_options is not None
 
-    # Test indentation
+    # Indentation, lists, and other tools
     assert [{"indent": "-1"}, {"indent": "+1"}] in toolbar
-
-    # Test lists
     assert [{"list": "ordered"}, {"list": "bullet"}] in toolbar
-
-    # Test media and special elements
     assert ["link", "image", "video", "formula"] in toolbar
-
-    # Test code blocks
     assert ["blockquote", "code-block"] in toolbar
 
 
 def test_editor_html_mode(mock_streamlit, mock_quill, mock_session_state):
-    """Test if editor is configured to use HTML mode"""
+    """
+    Tests if the editor is set to HTML mode.
+    """
     from NoKeeA.UI.streamlit_content import content
     content()
 
-    # Verify session state initialization was called
     mock_session_state.assert_called_once()
-
     assert mock_quill.call_args[1]['html'] is True
+
+
+@pytest.fixture
+def setup_session(monkeypatch):
+    """
+    Sets up a mocked Streamlit environment for Wikipedia search testing.
+    """
+    mock_st = MagicMock()
+    mock_st.session_state = {
+        "editor_content": "",
+        "loaded_note": "",
+        "note_name": "",
+        "last_loaded_note": None,
+        "editor_key": "editor_123"
+    }
+    mock_st.text_input.return_value = "Python"
+    mock_st.button.side_effect = [True, True]  # First: search, second: insert
+    mock_st.expander.return_value.__enter__.return_value = True
+    mock_st.success = MagicMock()
+    mock_st.markdown = MagicMock()
+    mock_st.error = MagicMock()
+    mock_st.info = MagicMock()
+    mock_st.subheader = MagicMock()
+
+    monkeypatch.setattr(streamlit_content, "st", mock_st)
+    monkeypatch.setattr(streamlit_content, "st_quill", MagicMock(return_value="test content"))
+    monkeypatch.setattr(streamlit_content, "initialize_session_state", MagicMock())
+    return mock_st
+
+
+def test_wikipedia_search_and_insert(setup_session, monkeypatch):
+    """
+    Tests the Wikipedia search and insert functionality into the note.
+    """
+    mock_st = setup_session
+
+    # Mock Wikipedia result
+    mock_result = {
+        "summary": "Python ist eine Programmiersprache.",
+        "url": "https://de.wikipedia.org/wiki/Python"
+    }
+    monkeypatch.setattr(streamlit_content, "get_wikipedia_summary", lambda term: mock_result)
+
+    streamlit_content.content()
+
+    assert "wiki_result" not in mock_st.session_state
+    assert "Python ist eine Programmiersprache." in mock_st.session_state["editor_content"]
+    mock_st.success.assert_called()
+    mock_st.markdown.assert_called()
+
+
+def test_update_quill_editor_sets_new_key(monkeypatch):
+    """
+    Tests if `update_quill_editor()` sets a new key in session state.
+    """
+    monkeypatch.setattr(streamlit_content.st, "session_state", {"loaded_note": "TestNote"})
+    streamlit_content.update_quill_editor()
+    assert streamlit_content.st.session_state["editor_key"].startswith("editor_")

--- a/tests/UI/test_streamlit_ui.py
+++ b/tests/UI/test_streamlit_ui.py
@@ -17,7 +17,7 @@ def test_streamlit_ui():
     """Test if the streamlit UI can be loaded"""
     ui_path = os.getenv("STREAMLIT_UI_SCRIPT_TEST",
                         os.path.join("src", "NoKeeA", "UI", "streamlit_ui.py"))
-    _ = AppTest.from_file(ui_path).run()
+    _ = AppTest.from_file(ui_path).run(timeout=10)
 
 
 def test_page_config():

--- a/tests/utils/test_wikipedia_api.py
+++ b/tests/utils/test_wikipedia_api.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch, Mock
+from NoKeeA.utils.wikipedia_api import get_wikipedia_summary
+import wikipedia
+import pytest
+
+
+def test_get_wikipedia_summary_success():
+    """Test successful Wikipedia article retrieval."""
+    with patch('wikipedia.page') as mock_page, patch('wikipedia.summary') as mock_summary:
+        mock_page.return_value = Mock(url="https://test.com")
+        mock_summary.return_value = "This is a test article about Python programming."
+
+        result = get_wikipedia_summary("Python")
+
+        assert result is not None
+        assert isinstance(result, dict)
+        assert "summary" in result
+        assert "url" in result
+        assert "Python programming" in result["summary"]
+        assert result["url"] == "https://test.com"
+
+        mock_summary.assert_called_once_with("Python", sentences=3)
+
+
+def test_get_wikipedia_summary_disambiguation():
+    """Test disambiguation error when the term is ambiguous."""
+    with patch('wikipedia.page') as mock_page:
+        mock_page.side_effect = wikipedia.exceptions.DisambiguationError("Test", ["Option1", "Option2", "Option3"])
+
+        result = get_wikipedia_summary("AmbiguousTerm")
+
+        assert result is not None
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "Mehrdeutiger Begriff" in result["error"]
+        assert "Option1" in result["error"]
+
+
+def test_get_wikipedia_summary_page_error():
+    """Test page error when the article does not exist."""
+    with patch('wikipedia.page') as mock_page:
+        mock_page.side_effect = wikipedia.exceptions.PageError("NonexistentArticle123")
+
+        result = get_wikipedia_summary("NonexistentArticle123")
+
+        assert result is not None
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "Kein Wikipedia-Eintrag gefunden." in result["error"]
+
+
+def test_get_wikipedia_summary_empty_query():
+    """Test behavior when searching with an empty query string."""
+    with pytest.raises(wikipedia.exceptions.WikipediaException):
+        get_wikipedia_summary("")


### PR DESCRIPTION
This pull request implements the Wikipedia API integration for the rich text editor.

✔️ Implemented API handler to fetch Wikipedia summaries (`get_wikipedia_summary`)
✔️ Integrated Wikipedia search and insertion functionality into the Streamlit editor
✔️ Wrote comprehensive tests for editor behavior and Wikipedia API usage
✔️ Improved session state management to ensure editor consistency

Related tasks:
- CCS-28: Implement Wikipedia API
- CCS-29: Integrate Wikipedia search into UI
- CCS-30: Add tests for Wikipedia integration

This addresses the epic: CCS-25: Wikipedia API
